### PR TITLE
[WIP]: feat(typelint): add type linting

### DIFF
--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1,0 +1,1 @@
+declare module '*.json';

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1,1 +1,6 @@
 declare module '*.json';
+
+// TODO: When the PR (seen below) lands, we can remove this
+// and stop getting type errors from chalk
+// https://github.com/chalk/chalk/pull/256
+declare module 'chalk';

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -97,6 +97,7 @@ module.exports = (config) => {
         const configs = [].concat(config);
         const [first] = configs;
         const { watchOptions } = first;
+        /** @type {{stdin?: string}} */
         const { stdin } = watchOptions || {};
         const callback = makeCallback({
           compiler,

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
   "devDependencies": {
     "@commitlint/cli": "^6.1.3",
     "@commitlint/config-conventional": "^6.1.3",
-    "@types/chalk": "^2.2.0",
     "@types/node": "^10.0.0",
     "@webpack-contrib/eslint-config-webpack": "^2.0.4",
     "babel-cli": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -17,26 +17,28 @@
   "scripts": {
     "commitlint": "commitlint",
     "commitmsg": "commitlint -e $GIT_PARAMS",
-    "lint": "eslint --cache lib test",
+    "lint": "eslint --cache lib test && npm run type-lint",
+    "type-lint": "tsc",
     "ci:lint:commits": "commitlint --from=${CIRCLE_BRANCH} --to=${CIRCLE_SHA1}",
     "lint-staged": "lint-staged",
-    "prepublishOnly": "mkdir -p data && cp -r lib/commands/defaults.json data/commands.json",
+    "prepublishOnly":
+      "mkdir -p data && cp -r lib/commands/defaults.json data/commands.json",
     "release": "standard-version",
     "release:ci": "conventional-github-releaser -p angular",
-    "release:validate": "commitlint --from=$(git describe --tags --abbrev=0) --to=$(git rev-parse HEAD)",
+    "release:validate":
+      "commitlint --from=$(git describe --tags --abbrev=0) --to=$(git rev-parse HEAD)",
     "security": "nsp check",
     "test": "npm run prepublishOnly && mocha test/test.js --check-leaks --exit",
-    "test:coverage": "mkdir -p coverage && nyc --silent npm test && npm run test:coverage:report",
-    "test:coverage:report": "nyc report --reporter=lcov --reporter=text-lcov --reporter=json --reporter=clover > coverage/lcov.info",
+    "test:coverage":
+      "mkdir -p coverage && nyc --silent npm test && npm run test:coverage:report",
+    "test:coverage:report":
+      "nyc report --reporter=lcov --reporter=text-lcov --reporter=json --reporter=clover > coverage/lcov.info",
     "ci:lint": "npm run lint && npm run security",
     "ci:test": "npm run test -- --runInBand",
     "ci:coverage": "npm run test:coverage -- --runInBand",
     "defaults": "webpack-defaults"
   },
-  "files": [
-    "data/",
-    "lib/"
-  ],
+  "files": ["data/", "lib/"],
   "peerDependencies": {
     "enhanced-resolve": "^4.0.0",
     "loader-utils": "^1.1.0",
@@ -73,6 +75,8 @@
   "devDependencies": {
     "@commitlint/cli": "^6.1.3",
     "@commitlint/config-conventional": "^6.1.3",
+    "@types/chalk": "^2.2.0",
+    "@types/node": "^10.0.0",
     "@webpack-contrib/eslint-config-webpack": "^2.0.4",
     "babel-cli": "^6.26.0",
     "babel-jest": "^22.4.3",
@@ -109,22 +113,16 @@
     "prettier": "^1.11.1",
     "standard-version": "^4.3.0",
     "stylelint-webpack-plugin": "^0.10.4",
+    "typescript": "^2.9.0-dev.20180429",
     "webpack": "^4.6.0",
     "webpack-defaults": "^2.3.0"
   },
-  "keywords": [
-    "webpack"
-  ],
+  "keywords": ["webpack"],
   "pre-commit": "lint-staged",
   "lint-staged": {
-    "*.js": [
-      "eslint --fix",
-      "git add"
-    ]
+    "*.js": ["eslint --fix", "git add"]
   },
   "nyc": {
-    "include": [
-      "lib/**/*.js"
-    ]
+    "include": ["lib/**/*.js"]
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,65 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    "target":
+      "ES2017" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
+    "module":
+      "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
+    "lib": [
+      "es2017",
+      "dom"
+    ] /* Specify library files to be included in the compilation. */,
+    "allowJs": true /* Allow javascript files to be compiled. */,
+    "checkJs": true /* Report errors in .js files. */,
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    "noEmit": true /* Do not emit outputs. */,
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": false /* Enable all strict type-checking options. */,
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    "strictFunctionTypes": true /* Enable strict checking of function types. */,
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    "alwaysStrict": true /* Parse in strict mode and emit "use strict" for each source file. */,
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    "types": [
+      "node"
+    ] /* Type declaration files to be included in compilation. */,
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+
+    /* Source Map Options */
+    // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+  },
+  "include": ["./declarations.d.ts", "bin/*.js", "lib/**/*.js"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,8 +6,7 @@
     "module":
       "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
     "lib": [
-      "es2017",
-      "dom"
+      "es2017"
     ] /* Specify library files to be included in the compilation. */,
     "allowJs": true /* Allow javascript files to be compiled. */,
     "checkJs": true /* Report errors in .js files. */,
@@ -26,10 +25,10 @@
     /* Strict Type-Checking Options */
     "strict": false /* Enable all strict type-checking options. */,
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,              /* Enable strict null checks. */
+    "strictNullChecks": true /* Enable strict null checks. */,
     "strictFunctionTypes": true /* Enable strict checking of function types. */,
-    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    "strictPropertyInitialization": true /* Enable strict checking of property initialization in classes. */,
+    "noImplicitThis": true /* Raise error on 'this' expressions with an implied 'any' type. */,
     "alwaysStrict": true /* Parse in strict mode and emit "use strict" for each source file. */,
 
     /* Additional Checks */


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case
After spending some time working on the TypeScript checking support in webpack, and how many things its been able to spot, I wanted to also start adopting it across a few projects. It would run just like eslint, and catch type errors in Editors like vs-code and in CI. We can make checking as strict or as loose as desired (I set it to the default non-superstrict). 
<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes
Nope!
<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
There were about 30ish errors spotted on initial run locally so I expect CI to fail, but I'll fix those individual issues in separate PR's each. 

Fixes: 
- [ ] #6 - For initial support (maybe still errors with stricter checks on)