### PR TITLE
refactor: update config-loader, cosmiconfig

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -36,7 +36,7 @@ module.exports = {
 
   load(argv, options) {
     const loaderOptions = {
-      allowZero: true,
+      allowMissing: true,
       configPath: argv.config,
       require: argv.require,
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -420,16 +420,27 @@
       "dev": true
     },
     "@webpack-contrib/config-loader": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@webpack-contrib/config-loader/-/config-loader-0.2.1.tgz",
-      "integrity": "sha512-zWVg0Z/FLEqUtq8sb1ePDWQY78boA4OBb1h0GQ1pchbQs/rzO1g+C/rtU/uFkL0PkxwThg2mc3UsMjE5QF3kKw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@webpack-contrib/config-loader/-/config-loader-1.0.0.tgz",
+      "integrity": "sha512-a1GPGvZTmgUkqt2PGxR0noWoCAMnNyf6tbk17VpmV/QMY9StS9yQIkuzxmnzVNSQ6yhTAOkS3kA9Cg+Xf8MPsg==",
       "requires": {
         "@webpack-contrib/schema-utils": "1.0.0-beta.0",
-        "cosmiconfig": "4.0.0",
+        "cosmiconfig": "5.0.2",
         "loud-rejection": "1.6.0",
-        "mock-require": "3.0.2",
         "resolve": "1.7.1",
         "webpack-log": "1.2.0"
+      },
+      "dependencies": {
+        "cosmiconfig": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.2.tgz",
+          "integrity": "sha512-zJV4MeVVN4DN/RdvqJURLFBnIfdwJDSHJ9IoxxqwnW48ZNKG9rbOEZb5tuWpnjLkqKCYvDKqGFt7egAUFHdakQ==",
+          "requires": {
+            "is-directory": "0.3.1",
+            "js-yaml": "3.11.0",
+            "parse-json": "4.0.0"
+          }
+        }
       }
     },
     "@webpack-contrib/eslint-config-webpack": {
@@ -2904,6 +2915,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
       "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
+      "dev": true,
       "requires": {
         "is-directory": "0.3.1",
         "js-yaml": "3.11.0",
@@ -5136,7 +5148,8 @@
     "get-caller-file": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+      "dev": true
     },
     "get-own-enumerable-property-symbols": {
       "version": "2.0.1",
@@ -8090,15 +8103,6 @@
         }
       }
     },
-    "mock-require": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mock-require/-/mock-require-3.0.2.tgz",
-      "integrity": "sha512-aD/Y1ZFHqw5pHg3HVQ50dLbfaAAcytS6sqLuhP51Dk3TSPdFb2VkSAa3mjrHifLIlGAtwQHJHINafAyqAne7vA==",
-      "requires": {
-        "get-caller-file": "1.0.2",
-        "normalize-path": "2.1.1"
-      }
-    },
     "modify-values": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
@@ -8310,6 +8314,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
       "requires": {
         "remove-trailing-separator": "1.1.0"
       }
@@ -12560,7 +12565,8 @@
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
     },
     "renderkid": {
       "version": "2.0.1",
@@ -12678,7 +12684,8 @@
     "require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
     },
     "require-main-filename": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "webpack": "^4.4.0"
   },
   "dependencies": {
-    "@webpack-contrib/config-loader": "^0.2.1",
+    "@webpack-contrib/config-loader": "^1.0.0",
     "@webpack-contrib/schema-utils": "^1.0.0-beta.0",
     "camelcase": "^5.0.0",
     "chalk": "^2.3.2",


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

A core dependency `@webpack-contrib/config-loader` received an update of `cosmiconfig` which removes the need for require hooking and mocking that was unstable in certain environments. 

### Breaking Changes

None

### Additional Info
