### PR TITLE
fix: check for --run-dev and --run-prod before other flags

### DIFF
--- a/lib/flags/general.js
+++ b/lib/flags/general.js
@@ -13,6 +13,31 @@ module.exports = {
       plugins = plugins.concat(options.plugins);
     }
 
+    // NOTE: runDev and runProd should be examined FIRST, as they manipulate
+    //       the argv object. Manipulating argv is bad and should make us feel
+    //       bad.
+    /* eslint-disable no-param-reassign */
+    if (argv.runDev) {
+      argv.debug = true;
+      argv['output-pathinfo'] = true;
+      if (!argv.devtool) {
+        argv.devtool = 'eval-cheap-module-source-map';
+      }
+      if (!argv.mode) {
+        argv.mode = 'development';
+      }
+    }
+
+    if (argv.runProd) {
+      argv['optimize-minimize'] = true;
+      argv.define = []
+        .concat(argv.define || [])
+        .concat('process.env.NODE_ENV="production"');
+      if (!argv.mode) {
+        argv.mode = 'production';
+      }
+    }
+
     if (argv.context) {
       result.context = path.resolve(argv.context);
     } else {
@@ -39,31 +64,6 @@ module.exports = {
 
     if (argv.reporter) {
       result.reporter = argv.reporter;
-    }
-
-    // NOTE: runDev and runProd should be examined FIRST, as they maniuplate
-    //       the argv object. maniuplating argv is bad and should make us feel
-    //       bad.
-    /* eslint-disable no-param-reassign */
-    if (argv.runDev) {
-      argv.debug = true;
-      argv['output-pathinfo'] = true;
-      if (!argv.devtool) {
-        argv.devtool = 'eval-cheap-module-source-map';
-      }
-      if (!argv.mode) {
-        argv.mode = 'development';
-      }
-    }
-
-    if (argv.runProd) {
-      argv['optimize-minimize'] = true;
-      argv.define = []
-        .concat(argv.define || [])
-        .concat('process.env.NODE_ENV="production"');
-      if (!argv.mode) {
-        argv.mode = 'production';
-      }
     }
 
     if (argv.watch) {

--- a/test/tests/flags/__snapshots__/run-mode.js.snap
+++ b/test/tests/flags/__snapshots__/run-mode.js.snap
@@ -3,9 +3,18 @@
 exports[`Flags > --run-dev > should apply #0 1`] = `
 Object {
   "context": "<PROJECT_ROOT>",
+  "devtool": "eval-cheap-module-source-map",
   "entry": "<PROJECT_ROOT>/test/fixtures/common/entry-a.js",
   "mode": "development",
   "plugins": Array [
+    LoaderOptionsPlugin {
+      "options": Object {
+        "debug": true,
+        "test": Object {
+          "test": [Function],
+        },
+      },
+    },
     NamedModulesPlugin {
       "options": Object {},
     },
@@ -17,12 +26,12 @@ Object {
 exports[`Flags > --run-dev > should build #0 1`] = `
 "Version: webpack 4.6.0
   Asset      Size  Chunks             Chunk Names
-main.js  2.96 KiB    main  [emitted]  main
+main.js  3.36 KiB    main  [emitted]  main
 Entrypoint main = main.js
 [./test/fixtures/common/entry-a.js] 41 bytes {main} [built]"
 `;
 
-exports[`Flags > --run-dev > should build #1 1`] = `"bf58edd8"`;
+exports[`Flags > --run-dev > should build #1 1`] = `"1f4895c0"`;
 
 exports[`Flags > --run-prod > should apply #0 1`] = `
 Object {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Like the code comment explains, these shortcut flags should be checked before others, so that they can set other flags. These checks were ordered alphabetically in previous refactoring, causing `--run-dev` to not set `--debug` and `--devtool=cheap-module-eval-source-map` like it should. This PR fixes the issue by moving the checks for these flags first again.

### Breaking Changes

None

### Additional Info
