### PR TITLE
feat: warn if bail is used in watch mode

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,5 +1,6 @@
 const camelcase = require('camelcase');
 const capitalize = require('titleize');
+const chalk = require('chalk');
 const merge = require('merge-options');
 const webpack = require('webpack');
 const weblog = require('webpack-log');
@@ -115,6 +116,14 @@ module.exports = (config) => {
 
         if (first.watch) {
           log.info('Watching enabled');
+          for (const c of configs) {
+            if (c.bail) {
+              log.warn(
+                chalk`Option {bold \`bail\`} will force webpack to exit on the first error`
+              );
+              break;
+            }
+          }
           compiler.watch(watchOptions, callback);
         } else {
           compiler.run(callback);


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

When running in watch mode, if the `bail` option is set, the process would exit on the first error. This PR introduces a warning to tell the user about the possible termination of its process.

This has been discussed on webpack repository: https://github.com/webpack/webpack/issues/6498

### Breaking Changes

no

### Additional Info
