### PR TITLE
feat: allow --reporter to be relative to CWD

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -51,7 +51,7 @@ function requireReporter(name) {
     } catch (e) {
       // noop
     }
-    
+
     if (result) {
       break;
     }

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -40,27 +40,20 @@ function makeCallback(options) {
  * to the current working directory.
  */
 function requireReporter(name) {
-  try {
-    const prefix = capitalize(camelcase(name));
-    // eslint-disable-next-line import/no-dynamic-require, global-require
-    const result = require(`./reporters/${prefix}Reporter`);
-    return result;
-  } catch (e1) {
+  const prefix = capitalize(camelcase(name));
+  const locations = [`./reporters/${prefix}Reporter`, name, path.resolve(name)];
+  let result = null;
+
+  for (const location of locations) {
     try {
       // eslint-disable-next-line import/no-dynamic-require, global-require
-      const result = require(name);
-      return result;
-    } catch (e2) {
-      try {
-        // eslint-disable-next-line import/no-dynamic-require, global-require
-        const result = require(path.resolve(name));
-        return result;
-      } catch (e3) {
-        // empty
-      }
+      result = require(location);
+    } catch (e) {
+      // noop
     }
   }
-  return null;
+
+  return result;
 }
 
 /**

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 const camelcase = require('camelcase');
 const capitalize = require('titleize');
 const merge = require('merge-options');
@@ -34,23 +36,31 @@ function makeCallback(options) {
 /**
  * Attempts to require a specified reporter. Tries the local built-ins first,
  * and if that fails, attempts to load an npm module that exports a reporter
- * handler function.
+ * handler function, and if that fails, attempts to load the reporter relative
+ * to the current working directory.
  */
-function requireReporter(name, local = true) {
-  const prefix = capitalize(camelcase(name));
-  const target = local ? `./reporters/${prefix}Reporter` : name;
-
+function requireReporter(name) {
   try {
+    const prefix = capitalize(camelcase(name));
     // eslint-disable-next-line import/no-dynamic-require, global-require
-    const result = require(target);
+    const result = require(`./reporters/${prefix}Reporter`);
     return result;
-  } catch (e) {
-    if (local) {
-      return requireReporter(name, false);
+  } catch (e1) {
+    try {
+      // eslint-disable-next-line import/no-dynamic-require, global-require
+      const result = require(name);
+      return result;
+    } catch (e2) {
+      try {
+        // eslint-disable-next-line import/no-dynamic-require, global-require
+        const result = require(path.resolve(name));
+        return result;
+      } catch (e3) {
+        // empty
+      }
     }
-
-    return null;
   }
+  return null;
 }
 
 /**

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -51,6 +51,10 @@ function requireReporter(name) {
     } catch (e) {
       // noop
     }
+    
+    if (result) {
+      break;
+    }
   }
 
   return result;

--- a/test/tests/__snapshots__/cli.js.snap
+++ b/test/tests/__snapshots__/cli.js.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Commands > should accept custom reporters relative to the current working directory #0 1`] = `
+"ℹ ｢webpack｣: Starting Build
+ℹ ｢webpack｣: Build Finished
+Hash: 953ce188d35af8c002f0
+<version>
+<duration>
+<datetime>
+  Asset       Size  Chunks             Chunk Names
+main.js  573 bytes       0  [emitted]  main
+Entrypoint main = main.js
+[0] ../fixtures/flags/config/src/index.js 43 bytes {0} [built]
+
+WARNING in configuration
+The 'mode' option has not been set, webpack will fallback to 'production' for this value. Set 'mode' option to 'development' or 'production' to enable defaults for each environment.
+You can also set it to 'none' to disable any default behavior. Learn more: https://webpack.js.org/concepts/mode/"
+`;
+
 exports[`Commands > should add directories to entries #0 1`] = `
 "ℹ ｢webpack｣: Starting Build
 ℹ ｢webpack｣: Build Finished

--- a/test/tests/cli.js
+++ b/test/tests/cli.js
@@ -79,4 +79,23 @@ test('Commands', module, () => {
       strip(result.stdout).replace(/Δt \d+ms/g, '<duration>')
     ).toMatchSnapshot();
   }).timeout(4000);
+
+  it('should accept custom reporters relative to the current working directory', () => {
+    const cliPath = resolve(__dirname, '../../lib/cli.js');
+    const srcPath = resolve(__dirname, '../../test/fixtures/flags/config/src');
+    const result = execa.sync(
+      cliPath,
+      ['--reporter', '../../lib/reporters/BasicReporter', srcPath],
+      {
+        cwd: __dirname,
+      }
+    );
+
+    expect(
+      strip(result.stdout)
+        .replace(/Version: webpack \d\.\d\.\d/, '<version>')
+        .replace(/Time: \d+ms/g, '<duration>')
+        .replace(/Built at: .+(?=\n)/g, '<datetime>')
+    ).toMatchSnapshot();
+  }).timeout(4000);
 });


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] new **feature**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->

### Motivation / Use-Case

Previously, the `--reporter` path must have been either absolute or in node_modules or relative to lib/compiler.js.

This change ensures that a path passed to `--reporter` is resolved relative to `process.cwd()`.

e.g. you can now run this inside of a project directory to use a custom reporter:

    webpack --reporter ./MyCustomReporter.js

### Breaking Changes

None
