### PR TITLE
fix: mode undefined in multi config

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,7 +1,7 @@
 const { isAbsolute, resolve } = require('path');
 
 const loader = require('@webpack-contrib/config-loader');
-const merge = require('merge-options');
+const merge = require('merge-options').bind({ concatArrays: true });
 
 const WebpackCommandError = require('./WebpackCommandError');
 
@@ -10,23 +10,9 @@ module.exports = {
     let result;
 
     if (Array.isArray(config)) {
-      result = config.map((conf) => {
-        const res = merge(conf, options);
-        const { plugins } = conf;
-
-        if (plugins && Array.isArray(plugins) && options.plugins) {
-          res.plugins = plugins.concat(options.plugins);
-        }
-
-        return res;
-      });
+      result = config.map((conf) => merge(conf, options));
     } else {
-      result = merge(options, config);
-      const { plugins } = result;
-
-      if (plugins && Array.isArray(plugins) && options.plugins) {
-        result.plugins = plugins.concat(options.plugins);
-      }
+      result = merge(config, options);
     }
 
     if (argv.configName) {

--- a/lib/flags/config.js
+++ b/lib/flags/config.js
@@ -2,15 +2,19 @@ const merge = require('merge-options');
 
 module.exports = {
   apply(argv, options) {
+    const result = {};
+
     if (argv.configRegister) {
       /* istanbul ignore next */
       // eslint-disable-next-line no-param-reassign
       argv.require = argv.configRegister;
     }
 
-    const result = merge(options, { mode: argv.mode });
+    if (argv.mode) {
+      result.mode = argv.mode;
+    }
 
-    return result;
+    return merge(options, result);
   },
 
   flags: {

--- a/test/test.js
+++ b/test/test.js
@@ -15,45 +15,45 @@ global.fixturePath = (path) => join(__dirname, './fixtures', path);
 
 require('./snapshot');
 
-require('./tests/commands/command');
-require('./tests/commands/help');
-require('./tests/commands/teach');
+// require('./tests/commands/command');
+// require('./tests/commands/help');
+// require('./tests/commands/teach');
 
-require('./tests/cli');
+// require('./tests/cli');
 require('./tests/config');
-require('./tests/flags');
-require('./tests/progress');
-require('./tests/reporters');
-
-const flags = [
-  'bail',
-  'cache',
-  'config',
-  'config-name',
-  'context',
-  'debug',
-  'define',
-  'devtool',
-  'entry',
-  'hot',
-  'mode',
-  'module-bind',
-  'optimize',
-  'output',
-  'plugin',
-  'prefetch',
-  'profile',
-  'provide',
-  'records',
-  'reporter',
-  'resolve',
-  'run-mode',
-  'target',
-  'watch',
-];
-
-describe('Flags', () => {
-  for (const test of flags) {
-    require(`./tests/flags/${test}`);
-  }
-});
+// require('./tests/flags');
+// require('./tests/progress');
+// require('./tests/reporters');
+//
+// const flags = [
+//   'bail',
+//   'cache',
+//   'config',
+//   'config-name',
+//   'context',
+//   'debug',
+//   'define',
+//   'devtool',
+//   'entry',
+//   'hot',
+//   'mode',
+//   'module-bind',
+//   'optimize',
+//   'output',
+//   'plugin',
+//   'prefetch',
+//   'profile',
+//   'provide',
+//   'records',
+//   'reporter',
+//   'resolve',
+//   'run-mode',
+//   'target',
+//   'watch',
+// ];
+//
+// describe('Flags', () => {
+//   for (const test of flags) {
+//     require(`./tests/flags/${test}`);
+//   }
+// });

--- a/test/test.js
+++ b/test/test.js
@@ -15,45 +15,45 @@ global.fixturePath = (path) => join(__dirname, './fixtures', path);
 
 require('./snapshot');
 
-// require('./tests/commands/command');
-// require('./tests/commands/help');
-// require('./tests/commands/teach');
+require('./tests/commands/command');
+require('./tests/commands/help');
+require('./tests/commands/teach');
 
-// require('./tests/cli');
+require('./tests/cli');
 require('./tests/config');
-// require('./tests/flags');
-// require('./tests/progress');
-// require('./tests/reporters');
-//
-// const flags = [
-//   'bail',
-//   'cache',
-//   'config',
-//   'config-name',
-//   'context',
-//   'debug',
-//   'define',
-//   'devtool',
-//   'entry',
-//   'hot',
-//   'mode',
-//   'module-bind',
-//   'optimize',
-//   'output',
-//   'plugin',
-//   'prefetch',
-//   'profile',
-//   'provide',
-//   'records',
-//   'reporter',
-//   'resolve',
-//   'run-mode',
-//   'target',
-//   'watch',
-// ];
-//
-// describe('Flags', () => {
-//   for (const test of flags) {
-//     require(`./tests/flags/${test}`);
-//   }
-// });
+require('./tests/flags');
+require('./tests/progress');
+require('./tests/reporters');
+
+const flags = [
+  'bail',
+  'cache',
+  'config',
+  'config-name',
+  'context',
+  'debug',
+  'define',
+  'devtool',
+  'entry',
+  'hot',
+  'mode',
+  'module-bind',
+  'optimize',
+  'output',
+  'plugin',
+  'prefetch',
+  'profile',
+  'provide',
+  'records',
+  'reporter',
+  'resolve',
+  'run-mode',
+  'target',
+  'watch',
+];
+
+describe('Flags', () => {
+  for (const test of flags) {
+    require(`./tests/flags/${test}`);
+  }
+});

--- a/test/tests/__snapshots__/config.js.snap
+++ b/test/tests/__snapshots__/config.js.snap
@@ -18,12 +18,32 @@ Object {
   "entry": "<PROJECT_ROOT>/common/entry-b.js",
   "mode": "development",
   "name": "test",
+  "plugins": Array [
+    1,
+  ],
 }
 `;
 
 exports[`lib/config > distill() plugins #0 1`] = `
 Object {
   "plugins": Array [
+    1,
+  ],
+}
+`;
+
+exports[`lib/config > distill() plugins #1 1`] = `
+Object {
+  "plugins": Array [
+    1,
+  ],
+}
+`;
+
+exports[`lib/config > distill() plugins #2 1`] = `
+Object {
+  "plugins": Array [
+    1,
     1,
   ],
 }
@@ -42,6 +62,45 @@ Array [
     "entry": "<PROJECT_ROOT>/common/entry-b.js",
     "mode": "development",
     "plugins": Array [
+      1,
+    ],
+  },
+]
+`;
+
+exports[`lib/config > distill() plugins from config array #1 1`] = `
+Array [
+  Object {
+    "entry": "<PROJECT_ROOT>/common/entry-a.js",
+    "mode": "development",
+    "plugins": Array [
+      1,
+    ],
+  },
+  Object {
+    "entry": "<PROJECT_ROOT>/common/entry-b.js",
+    "mode": "development",
+    "plugins": Array [
+      1,
+    ],
+  },
+]
+`;
+
+exports[`lib/config > distill() plugins from config array #2 1`] = `
+Array [
+  Object {
+    "entry": "<PROJECT_ROOT>/common/entry-a.js",
+    "mode": "development",
+    "plugins": Array [
+      1,
+    ],
+  },
+  Object {
+    "entry": "<PROJECT_ROOT>/common/entry-b.js",
+    "mode": "development",
+    "plugins": Array [
+      1,
       1,
     ],
   },

--- a/test/tests/__snapshots__/flags.js.snap
+++ b/test/tests/__snapshots__/flags.js.snap
@@ -150,6 +150,13 @@ exports[`lib/flags > should display help #1 1`] = `
 "
 `;
 
+exports[`lib/flags > should parse flags cleanly #0 1`] = `
+Object {
+  "context": "<PROJECT_ROOT>",
+  "output": Object {},
+}
+`;
+
 exports[`lib/flags > should return minimist opts #0 1`] = `
 Object {
   "bail": Object {

--- a/test/tests/config.js
+++ b/test/tests/config.js
@@ -19,14 +19,30 @@ test('lib/config', module, () => {
   });
 
   it(`distill() plugins`, () => {
-    const result = distill({}, { plugins: [] }, { plugins: [1] });
+    let result = distill({}, {}, { plugins: [1] });
+    expect(result).toMatchSnapshot();
+
+    result = distill({}, { plugins: [] }, { plugins: [1] });
+    expect(result).toMatchSnapshot();
+
+    result = distill({}, { plugins: [1] }, { plugins: [1] });
     expect(result).toMatchSnapshot();
   });
 
   it(`distill() plugins from config array`, () => {
     const conf = [].concat(config);
+    let result = distill({}, conf, { plugins: [1] });
+
+    expect(result).toMatchSnapshot();
+
     conf[0].plugins = [];
-    const result = distill({}, conf, { plugins: [1] });
+    result = distill({}, conf, { plugins: [1] });
+
+    expect(result).toMatchSnapshot();
+
+    conf[1].plugins = [1];
+    result = distill({}, conf, { plugins: [1] });
+
     expect(result).toMatchSnapshot();
   });
 

--- a/test/tests/flags.js
+++ b/test/tests/flags.js
@@ -12,6 +12,11 @@ test('lib/flags', module, () => {
     const result = flags.opts();
     expect(result).toMatchSnapshot();
   });
+
+  it('should parse flags cleanly', () => {
+    const result = flags.apply({}, {});
+    expect(result).toMatchSnapshot();
+  });
 });
 
 test('lib/flags/util', module, () => {


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

#27 revealed bug by which the `mode` config property was being overridden in multi-compiler configs. Fixes #27.

### Breaking Changes

None

### Additional Info
