### PR TITLE
fix: allow invocation from webpack/bin/webpack.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "bin": {
     "webpack": "lib/cli.js"
   },
-  "main": "lib/index.js",
+  "main": "lib/cli.js",
   "engines": {
     "node": ">= 6.9.0 <7.0.0 || >= 8.9.0"
   },


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

Because both [webpack](https://github.com/webpack/webpack/blob/02a955b4335cb7eeeb4dd1c96ef5407c6bcea158/package.json#L92) and [webpack-command](https://github.com/webpack-contrib/webpack-command/blob/63c94a347cc67f3d14b6e99d9416a0c6866751b8/package.json#L10-L12) define a `"bin"` called "webpack" in their respective package.json manifests, there is ambiguity over which one will be linked at `node_modules/.bin/webpack`. When using [pnpm](https://github.com/pnpm/pnpm), it turns out webpack's binary is linked rather than webpack-command's. So when `node_modules/.bin/webpack` is invoked, [this is called](https://github.com/webpack/webpack/blob/02a955b4335cb7eeeb4dd1c96ef5407c6bcea158/bin/webpack.js#L157):

```js
require(installedClis[0].package);
// where installedClis[0].package === 'webpack-command'
```

This currently causes the command to output nothing because webpack-command's "main" module [lib/index.js](https://github.com/webpack-contrib/webpack-command/blob/63c94a347cc67f3d14b6e99d9416a0c6866751b8/lib/index.js) does not launch the CLI.

Changing the "main" field to reference `lib/cli.js` fixes this issue, the [same as how it works for webpack-cli](https://github.com/webpack/webpack-cli/blob/945be4b100461b8227a79e15db08a78119004fc5/package.json#L13).

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

This breaks any consumers of webpack-command which expect `require('webpack-command')` to return the exports of `lib/index.js`. To avoid this breaking change, I can think of two approaches:
1. Keep `"main": "lib/index.js"`, but do some detection at the module scope of `lib/index.js` to detect whether it's being invoked as a CLI. I'm not too sure what this would look like though.
2. Instead, change `webpack/bin/webpack.js`'s implementation to import and execute some function exported by webpack-command, instead of relying on the side effects of `require(installedClis[0].package);`. This would introduce some inconsistency with how webpack-cli is invoked, so maybe some changes should be made over in webpack-cli too.
