### PR TITLE
Fix/run mode

### DIFF
--- a/lib/flags/advanced.js
+++ b/lib/flags/advanced.js
@@ -100,7 +100,8 @@ module.exports = {
     },
     define: {
       type: 'object',
-      desc: 'Define any free var in the bundle',
+      desc: `Used to redefine or replace a variable or key in the bundle. Complex
+keys should be set in config. {dim e.g. --define.batman robin}`,
     },
     hot: {
       type: 'boolean',

--- a/lib/flags/general.js
+++ b/lib/flags/general.js
@@ -19,7 +19,7 @@ module.exports = {
     /* eslint-disable no-param-reassign */
     if (argv.runDev) {
       argv.debug = true;
-      argv['output-pathinfo'] = true;
+      argv.outputPathinfo = true;
       if (!argv.devtool) {
         argv.devtool = 'eval-cheap-module-source-map';
       }
@@ -29,10 +29,10 @@ module.exports = {
     }
 
     if (argv.runProd) {
-      argv['optimize-minimize'] = true;
-      argv.define = []
-        .concat(argv.define || [])
-        .concat('process.env.NODE_ENV="production"');
+      argv.optimizeMinimize = true;
+      argv.define = Object.assign({}, argv.define, {
+        'process.env.NODE_ENV': 'production',
+      });
       if (!argv.mode) {
         argv.mode = 'production';
       }
@@ -126,7 +126,7 @@ Typically used for language-specific require hooks`,
     'run-prod': {
       alias: 'p',
       desc:
-        'An alias for --optimize-minimize --define process.env.NODE_ENV="production"',
+        'An alias for --optimize-minimize, which also defines process.env.NODE_ENV="production"',
       type: 'boolean',
     },
     version: {

--- a/test/snapshot.js
+++ b/test/snapshot.js
@@ -49,7 +49,7 @@ function nameTest(test) {
 function match(received) {
   const { file } = current;
   const snapshotState = new SnapshotState(file, {
-    updateSnapshot: argv.update ? 'all' : 'new',
+    updateSnapshot: argv.update || argv.u ? 'all' : 'new',
   });
   const matcher = toMatchSnapshot.bind({
     snapshotState,

--- a/test/tests/__snapshots__/flags.js.snap
+++ b/test/tests/__snapshots__/flags.js.snap
@@ -150,6 +150,58 @@ exports[`lib/flags > should display help #1 1`] = `
 "
 `;
 
+exports[`lib/flags > should parse compound flags: --run-dev #0 1`] = `
+Object {
+  "context": "<PROJECT_ROOT>",
+  "devtool": "eval-cheap-module-source-map",
+  "mode": "development",
+  "output": Object {
+    "pathinfo": true,
+  },
+  "plugins": Array [
+    LoaderOptionsPlugin {
+      "options": Object {
+        "debug": true,
+        "test": Object {
+          "test": [Function],
+        },
+      },
+    },
+    NamedModulesPlugin {
+      "options": Object {},
+    },
+  ],
+  "reporter": "<PROJECT_ROOT>/test/fixtures/common/test-reporter.js",
+}
+`;
+
+exports[`lib/flags > should parse compound flags: --run-prod #0 1`] = `
+Object {
+  "context": "<PROJECT_ROOT>",
+  "mode": "production",
+  "output": Object {},
+  "plugins": Array [
+    LoaderOptionsPlugin {
+      "options": Object {
+        "minimize": true,
+        "test": Object {
+          "test": [Function],
+        },
+      },
+    },
+    DefinePlugin {
+      "definitions": Object {
+        "process.env.NODE_ENV": "production",
+      },
+    },
+    NamedModulesPlugin {
+      "options": Object {},
+    },
+  ],
+  "reporter": "<PROJECT_ROOT>/test/fixtures/common/test-reporter.js",
+}
+`;
+
 exports[`lib/flags > should parse flags cleanly #0 1`] = `
 Object {
   "context": "<PROJECT_ROOT>",

--- a/test/tests/flags.js
+++ b/test/tests/flags.js
@@ -2,6 +2,8 @@ const { test } = require('../util');
 const flags = require('../../lib/flags');
 const { validateFlags } = require('../../lib/flags/util');
 
+const config = require('../fixtures/common/webpack.config.js');
+
 test('lib/flags', module, () => {
   it(`should display help`, () => {
     const result = flags.help();
@@ -15,6 +17,16 @@ test('lib/flags', module, () => {
 
   it('should parse flags cleanly', () => {
     const result = flags.apply({}, {});
+    expect(result).toMatchSnapshot();
+  });
+
+  it('should parse compound flags: --run-dev', () => {
+    const result = flags.apply({ runDev: true }, config);
+    expect(result).toMatchSnapshot();
+  });
+
+  it('should parse compound flags: --run-prod', () => {
+    const result = flags.apply({ runProd: true }, config);
     expect(result).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

#33 raised an issue that `--define` was not clear exactly how it was supposed to be used. This PR adds a documentation enhancement to explain that in better detail.

That led me to examine how `--run-dev` and `--run-prod` were being applied, since `--define` is used with those flags. From there it was discovered that some holdover code from webpack-cli hadn't been replaced with the format and method valid for this module. That was resolved and tests were added to cover and assert those flags were being applied correctly.

### Breaking Changes

None

### Additional Info

None
