### PR TITLE
fix: add handling for exit codes on error

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -124,7 +124,7 @@ ${commandHelp()}
       }
 
       log(error.stack);
-      process.exit(1);
+      process.exitCode = 1;
     });
   }
 }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -23,6 +23,7 @@ function run() {
   /* eslint-disable global-require */
   const { existsSync: exists, statSync: stat } = require('fs');
   const { sep } = require('path');
+  const { inspect } = require('util');
 
   const chalk = require('chalk');
   const meow = require('meow');
@@ -111,6 +112,19 @@ ${commandHelp()}
       cli.entries = entries;
     }
 
-    woof(cli);
+    woof(cli).catch((e) => {
+      let error = e;
+      // eslint-disable-next-line no-shadow
+      const { error: log } = console;
+
+      if (!(error instanceof Error)) {
+        error = new Error(
+          `webpack-command failed with a value of: ${inspect(error)}`
+        );
+      }
+
+      log(error.stack);
+      process.exit(1);
+    });
   }
 }

--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -20,12 +20,12 @@ function makeCallback(options) {
       log.debug('Input File System Purged');
     }
 
+    const result = reporter.render(error, stats);
+
     if (error) {
       reject(error);
       return;
     }
-
-    const result = reporter.render(error, stats);
 
     resolve(result);
   };

--- a/test/fixtures/common/test-reporter.js
+++ b/test/fixtures/common/test-reporter.js
@@ -3,6 +3,10 @@ const WebpackCommandError = require('../../../lib/WebpackCommandError');
 
 module.exports = class TestReporter extends Reporter {
   render(error, stats) {
+    if (!stats) {
+      return null;
+    }
+
     if (stats.hasErrors()) {
       const info = stats.toJson();
       throw new WebpackCommandError(info.errors);


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

The author is MIA, but pretty sure this resolves #31. Exit code for webpack-command is always 0. I've added code to handle rejected compilations, display the error and exit with a nonzero. This also contains a change to the order of operations in `compiler.js` whereby reporters are given the chance to do something if there's an error in the build. 

### Breaking Changes

None

### Additional Info

_This really needs testing before it can be merged_ If anyone has suggestions for tests to force a build to fail with an error, rather than going through the build with errors, please post your suggestions. I'm at a bit of a loss. 