### PR TITLE
fix: context overriden by flags default value. fixes #36

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -7,12 +7,13 @@ const WebpackCommandError = require('./WebpackCommandError');
 
 module.exports = {
   distill(argv, config, options) {
+    const cwdContext = { context: process.cwd() };
     let result;
 
     if (Array.isArray(config)) {
-      result = config.map((conf) => merge(conf, options));
+      result = config.map((conf) => merge(cwdContext, conf, options));
     } else {
-      result = merge(config, options);
+      result = merge(cwdContext, config, options);
     }
 
     if (argv.configName) {

--- a/lib/flags/general.js
+++ b/lib/flags/general.js
@@ -40,9 +40,9 @@ module.exports = {
 
     if (argv.context) {
       result.context = path.resolve(argv.context);
-    } else {
-      result.context = process.cwd();
     }
+    // there is no else case for context, as we don't want a default value
+    // here to override a context value in a config
 
     if (argv.debug) {
       const { LoaderOptionsPlugin } = webpack;

--- a/test/tests/__snapshots__/config.js.snap
+++ b/test/tests/__snapshots__/config.js.snap
@@ -3,10 +3,12 @@
 exports[`lib/config > distill() #0 1`] = `
 Array [
   Object {
+    "context": "<PROJECT_ROOT>",
     "entry": "<PROJECT_ROOT>/common/entry-a.js",
     "mode": "development",
   },
   Object {
+    "context": "<PROJECT_ROOT>",
     "entry": "<PROJECT_ROOT>/common/entry-b.js",
     "mode": "development",
   },
@@ -26,6 +28,7 @@ Object {
 
 exports[`lib/config > distill() plugins #0 1`] = `
 Object {
+  "context": "<PROJECT_ROOT>",
   "plugins": Array [
     1,
   ],
@@ -34,6 +37,7 @@ Object {
 
 exports[`lib/config > distill() plugins #1 1`] = `
 Object {
+  "context": "<PROJECT_ROOT>",
   "plugins": Array [
     1,
   ],
@@ -42,6 +46,7 @@ Object {
 
 exports[`lib/config > distill() plugins #2 1`] = `
 Object {
+  "context": "<PROJECT_ROOT>",
   "plugins": Array [
     1,
     1,
@@ -52,6 +57,7 @@ Object {
 exports[`lib/config > distill() plugins from config array #0 1`] = `
 Array [
   Object {
+    "context": "<PROJECT_ROOT>",
     "entry": "<PROJECT_ROOT>/common/entry-a.js",
     "mode": "development",
     "plugins": Array [
@@ -59,6 +65,7 @@ Array [
     ],
   },
   Object {
+    "context": "<PROJECT_ROOT>",
     "entry": "<PROJECT_ROOT>/common/entry-b.js",
     "mode": "development",
     "plugins": Array [
@@ -71,6 +78,7 @@ Array [
 exports[`lib/config > distill() plugins from config array #1 1`] = `
 Array [
   Object {
+    "context": "<PROJECT_ROOT>",
     "entry": "<PROJECT_ROOT>/common/entry-a.js",
     "mode": "development",
     "plugins": Array [
@@ -78,6 +86,7 @@ Array [
     ],
   },
   Object {
+    "context": "<PROJECT_ROOT>",
     "entry": "<PROJECT_ROOT>/common/entry-b.js",
     "mode": "development",
     "plugins": Array [
@@ -90,6 +99,7 @@ Array [
 exports[`lib/config > distill() plugins from config array #2 1`] = `
 Array [
   Object {
+    "context": "<PROJECT_ROOT>",
     "entry": "<PROJECT_ROOT>/common/entry-a.js",
     "mode": "development",
     "plugins": Array [
@@ -97,6 +107,7 @@ Array [
     ],
   },
   Object {
+    "context": "<PROJECT_ROOT>",
     "entry": "<PROJECT_ROOT>/common/entry-b.js",
     "mode": "development",
     "plugins": Array [

--- a/test/tests/__snapshots__/flags.js.snap
+++ b/test/tests/__snapshots__/flags.js.snap
@@ -155,7 +155,6 @@ exports[`lib/flags > should display help #1 1`] = `
 
 exports[`lib/flags > should parse compound flags: --run-dev #0 1`] = `
 Object {
-  "context": "<PROJECT_ROOT>",
   "devtool": "eval-cheap-module-source-map",
   "mode": "development",
   "output": Object {
@@ -180,7 +179,6 @@ Object {
 
 exports[`lib/flags > should parse compound flags: --run-prod #0 1`] = `
 Object {
-  "context": "<PROJECT_ROOT>",
   "mode": "production",
   "output": Object {},
   "plugins": Array [
@@ -207,7 +205,6 @@ Object {
 
 exports[`lib/flags > should parse flags cleanly #0 1`] = `
 Object {
-  "context": "<PROJECT_ROOT>",
   "output": Object {},
 }
 `;

--- a/test/tests/__snapshots__/reporters.js.snap
+++ b/test/tests/__snapshots__/reporters.js.snap
@@ -2,7 +2,6 @@
 
 exports[`StylishReporter > problems/stylish-problems reporter should apply #0 1`] = `
 Object {
-  "context": "<PROJECT_ROOT>",
   "entry": "<PROJECT_ROOT>/test/fixtures/reporters/stylish/problems/entry-problems.js",
   "mode": "development",
   "plugins": Array [
@@ -46,7 +45,6 @@ webpack v4.6.0
 
 exports[`StylishReporter > stylish reporter should apply #0 1`] = `
 Object {
-  "context": "<PROJECT_ROOT>",
   "entry": "<PROJECT_ROOT>/test/fixtures/common/entry-a.js",
   "mode": "development",
   "plugins": Array [
@@ -75,7 +73,6 @@ webpack v4.6.0
 exports[`StylishReporter > stylish-multi reporter should apply #0 1`] = `
 Array [
   Object {
-    "context": "<PROJECT_ROOT>",
     "entry": "<PROJECT_ROOT>/test/fixtures/common/entry-a.js",
     "mode": "development",
     "plugins": Array [
@@ -85,7 +82,6 @@ Array [
     ],
   },
   Object {
-    "context": "<PROJECT_ROOT>",
     "entry": Array [
       "<PROJECT_ROOT>/test/fixtures/common/entry-b.js",
       "<PROJECT_ROOT>/test/fixtures/common/entry-c.js",

--- a/test/tests/config.js
+++ b/test/tests/config.js
@@ -1,5 +1,6 @@
 const { test } = require('../util');
 const { distill } = require('../../lib/config');
+const { apply } = require('../../lib/flags');
 
 const config = [
   {
@@ -16,6 +17,20 @@ test('lib/config', module, () => {
   it(`distill()`, () => {
     const result = distill({}, config, {});
     expect(result).toMatchSnapshot();
+  });
+
+  it(`distill() context`, () => {
+    const argv = {};
+    const options = apply({}, {});
+
+    let result = distill(argv, { context: 'batman' }, { context: 'superman' });
+    expect(result.context).toBe('superman');
+
+    result = distill(argv, { context: 'batman' }, options);
+    expect(result.context).toBe('batman');
+
+    result = distill(argv, {}, options);
+    expect(result.context).toBe(process.cwd());
   });
 
   it(`distill() plugins`, () => {

--- a/test/tests/flags/__snapshots__/debug.js.snap
+++ b/test/tests/flags/__snapshots__/debug.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Flags > --debug > should apply #0 1`] = `
 Object {
-  "context": "<PROJECT_ROOT>",
   "entry": "<PROJECT_ROOT>/test/fixtures/common/entry-a.js",
   "mode": "development",
   "plugins": Array [

--- a/test/tests/flags/__snapshots__/devtool.js.snap
+++ b/test/tests/flags/__snapshots__/devtool.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Flags > --devtool > should apply #0 1`] = `
 Object {
-  "context": "<PROJECT_ROOT>",
   "devtool": "cheap-source-map",
   "entry": "<PROJECT_ROOT>/test/fixtures/common/entry-a.js",
   "mode": "development",

--- a/test/tests/flags/__snapshots__/entry.js.snap
+++ b/test/tests/flags/__snapshots__/entry.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Flags > --entry > multi should apply #0 1`] = `
 Object {
-  "context": "<PROJECT_ROOT>",
   "entry": Object {
     "main": Array [
       "./test/fixtures/common/entry-a.js",

--- a/test/tests/flags/__snapshots__/reporter.js.snap
+++ b/test/tests/flags/__snapshots__/reporter.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Flags > --reporter > basic reporter should apply #0 1`] = `
 Object {
-  "context": "<PROJECT_ROOT>",
   "entry": "<PROJECT_ROOT>/test/fixtures/common/entry-a.js",
   "mode": "development",
   "plugins": Array [
@@ -32,7 +31,6 @@ exports[`Flags > --reporter > basic reporter should build #1 1`] = `"bf58edd8"`;
 exports[`Flags > --reporter > basic-multi reporter should apply #0 1`] = `
 Array [
   Object {
-    "context": "<PROJECT_ROOT>",
     "entry": "<PROJECT_ROOT>/test/fixtures/common/entry-a.js",
     "mode": "development",
     "plugins": Array [
@@ -43,7 +41,6 @@ Array [
     "reporter": "basic",
   },
   Object {
-    "context": "<PROJECT_ROOT>",
     "entry": Array [
       "<PROJECT_ROOT>/test/fixtures/common/entry-b.js",
       "<PROJECT_ROOT>/test/fixtures/common/entry-c.js",

--- a/test/tests/flags/__snapshots__/run-mode.js.snap
+++ b/test/tests/flags/__snapshots__/run-mode.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Flags > --run-dev > should apply #0 1`] = `
 Object {
-  "context": "<PROJECT_ROOT>",
   "devtool": "eval-cheap-module-source-map",
   "entry": "<PROJECT_ROOT>/test/fixtures/common/entry-a.js",
   "mode": "development",
@@ -35,7 +34,6 @@ exports[`Flags > --run-dev > should build #1 1`] = `"1f4895c0"`;
 
 exports[`Flags > --run-prod > should apply #0 1`] = `
 Object {
-  "context": "<PROJECT_ROOT>",
   "entry": "<PROJECT_ROOT>/test/fixtures/common/entry-a.js",
   "mode": "development",
   "plugins": Array [

--- a/test/tests/flags/__snapshots__/watch.js.snap
+++ b/test/tests/flags/__snapshots__/watch.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Flags > --watch > should apply #0 1`] = `
 Object {
-  "context": "<PROJECT_ROOT>",
   "entry": "<PROJECT_ROOT>/test/fixtures/common/entry-a.js",
   "mode": "development",
   "name": "single-flag",


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

[This comment](https://github.com/webpack-contrib/webpack-command/issues/36#issuecomment-399311305) on #36 exposed a bug in which the flags parsing code was overriding `context` as defined in configs, if the `--context` flag was not specified.

### Breaking Changes

None

### Additional Info

The bug was introduced in bfaa6991f444759b8ffe27dd34055a2c3f3e03d8. The fix was to put the burden of applying a default context to config(s) in the module responsible for loading and distilling the config(s) and flags. 

(Thanks to @LynnKirby for taking the time to identify the problem)