### PR TITLE
feat: export `wp` binary in package to avoid binary name conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "homepage": "https://github.com/webpack-contrib/webpack-command",
   "bugs": "https://github.com/webpack-contrib/webpack-command/issues",
   "bin": {
-    "webpack": "lib/cli.js"
+    "webpack": "lib/cli.js",
+    "wp": "lib/cli.js"
   },
   "main": "lib/index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "bugs": "https://github.com/webpack-contrib/webpack-command/issues",
   "bin": {
     "webpack": "lib/cli.js",
+    "webpack-command": "lib/cli.js",
     "wp": "lib/cli.js"
   },
   "main": "lib/index.js",


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Recent work on webpack (https://github.com/webpack/webpack/pull/7534) to resolve the exported bin file names between webpack-cli and `webpack-command` has highlighted the inability to have both webpack-cli and `webpack-command` installed without conflicts that will disable one or the other (depending on install order).

While this by no means solves that dilemma, this PR proposes to add an additional bin `wp` (shorthand for `webpack`) as an export, to allow `webpack-command` to be used in situations where webpack-cli must also be installed. 

### Breaking Changes

None

### Additional Info

No tests are needed for this as no code changes have been made. 

Please add your thoughts to this proposal. 