### PR TITLE
fix: preserve dynamic entry functions (#48)

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -76,12 +76,16 @@ function sanitize(config) {
     delete result.reporter;
     delete result.watchStdin;
 
-    // TODO: remove the need for this
-    for (const property of ['entry', 'output']) {
-      const target = result[property];
-      if (target && Object.keys(target).length === 0) {
-        delete result[property];
-      }
+    // TODO: remove the need for these cleanups
+    if (
+      result.entry &&
+      Object.keys(result.entry).length === 0 &&
+      !(result.entry instanceof Function)
+    ) {
+      delete result.entry;
+    }
+    if (result.output && Object.keys(result.output).length === 0) {
+      delete result.output;
     }
 
     return result;

--- a/test/fixtures/function-entry-config/webpack.config.js
+++ b/test/fixtures/function-entry-config/webpack.config.js
@@ -1,0 +1,5 @@
+const { resolve } = require('path');
+
+module.exports = {
+  entry: () => resolve(__dirname, 'webpack.config.js'),
+};

--- a/test/tests/cli.js
+++ b/test/tests/cli.js
@@ -18,6 +18,16 @@ test('Bad Config', module, () => {
   });
 });
 
+test('Function Entry Config', module, () => {
+  it('should be used', () => {
+    const cliPath = resolve(__dirname, '../../lib/cli');
+    const cwd = resolve(__dirname, '../fixtures/function-entry-config');
+
+    // This will report `Can't resolve './src'` if the entry function is lost.
+    expect(() => execa.sync('node', [cliPath], { cwd })).not.toThrow();
+  });
+});
+
 test('Zero Config', module, () => {
   it('should run', () => {
     const cliPath = resolve(__dirname, '../../lib/cli');


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

Maintainer has objections on the issue, so am tossing this up to make sure we're talking about the same thing.

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Dynamic entry functions do not work because they are discarded when sanitizing the configuration.

### Breaking Changes

No

### Additional Info

Unrolled the ['entry', 'output'] loop to keep exactly the same behavior on the result.output object.